### PR TITLE
Repair archive extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM larmog/armhf-alpine-java:jdk-8u73
 
 MAINTAINER Jay MOULIN <jaymoulin@gmail.com>
 
+# archive extraction uses sevenzipjbinding library
+# which is compiled against libstdc++
+RUN apk add --update libstdc++
+ENV LD_LIBRARY_PATH=/lib;/lib32;/usr/lib
+
 RUN mkdir /opt/JDownloader/
 
 ADD JDownloader.jar /opt/JDownloader/JDownloader.jar


### PR DESCRIPTION
At the moment, JDownloader is not able to extract any archive, because the used sevenzipjbinding-Library depends on pre-compiled shared objects, which have been compiled against glibc / libstdc++. 

At least one of the binaries works with musl libc, by installing libstdc++ we can solve this problem. 
Second, Java seems not to use the system linker to load depending shared objects - we need to give the load path in the environment (`LD_LIBRARY_PATH`). 

With these two changes, JDownloader is able to load the 7zip-bindings and extract archives (tested on a Raspberry Pi 3 + Raspbian Lite).