### PR TITLE
Improving stability of automatic updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /JDownloader.jar
+tini

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ MAINTAINER Jay MOULIN <jaymoulin@gmail.com>
 RUN apk add --update libstdc++
 ENV LD_LIBRARY_PATH=/lib;/lib32;/usr/lib
 
+ADD tini /sbin/tini
+
 RUN mkdir /opt/JDownloader/
 
 ADD JDownloader.jar /opt/JDownloader/JDownloader.jar
@@ -18,4 +20,4 @@ VOLUME /root/Downloads
 VOLUME /opt/JDownloader/cfg
 WORKDIR /opt/JDownloader
 
-CMD ["/opt/JDownloader/daemon.sh"]
+CMD ["/sbin/tini", "--", "/opt/JDownloader/daemon.sh"]

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 wget -O ./JDownloader.jar "http://installer.jdownloader.org/JDownloader.jar?$RANDOM" && chmod +x ./JDownloader.jar
+wget -O ./tini "https://github.com/krallin/tini/releases/download/v0.14.0/tini-static-armhf" && chmod +x tini
 
 docker build -t jaymoulin/rpi-jdownloader .

--- a/daemon.sh
+++ b/daemon.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 
 trap 'kill -TERM $PID' TERM INT
-rm /opt/JDownloader/JDownloader.jar.*
-rm /opt/JDownloader/JDownloader.pid
+rm -f /opt/JDownloader/JDownloader.jar.*
+rm -f /opt/JDownloader/JDownloader.pid
+
+# Check if JDownloader.jar exists, or if there is an interrupted update
+if [ ! -f /opt/JDownloader/JDownloader.jar ] && [ -f /opt/JDownloader/tmp/update/self/JDU/JDownloader.jar ]; then
+    cp /opt/JDownloader/tmp/update/self/JDU/JDownloader.jar /opt/JDownloader/
+fi
+
 java -Djava.awt.headless=true -jar /opt/JDownloader/JDownloader.jar &
 PID=$!
 wait $PID
 wait $PID
+
+# Debugging helper - if the container crashes, create a file called "jdownloader-block.txt" in the download folder
+# The container will not terminate (and you can run "docker exec -it ... bash")
+if [ -f /root/Downloads/jdownloader-block.txt ]; then
+    sleep 1000000
+fi
+
 EXIT_STATUS=$?


### PR DESCRIPTION
Today, container creation/startup failed many times because the automatic update broke the installation inside the container. This update runs everytime I create a new container. Apparently this happens because the update is performed by a second java process, while the first java process already terminates. Then docker terminates and kills the second process. 

This PR includes 3 changes that help to address this issue:
- First, the `daemon.sh` tries to recover an aborted update (resulting in a deleted `JDownloader.jar`)
- Next, I added `tini` (https://github.com/krallin/tini). It acts as lightweight init system and should in theory send SIGTERM signals to the updating processes (and reap them after container termination). I'm not sure if this is really necessary, but it's good anyways (read [this blog post](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/) for more details - tini is a C version of their python script)
- Last, I shared my debug hook with you - it might save you a lot of trouble if you need a debugging shell in a container that doesn't start any more

With these changes, my JDownloader container survived 2 updates. No guarantee I got all updating bugs through. 