### PR TITLE
Add ffmpeg package and update the package db

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@ MAINTAINER Jay MOULIN <jaymoulin@gmail.com>
 # archive extraction uses sevenzipjbinding library
 # which is compiled against libstdc++
 RUN mkdir /opt/JDownloader/
-RUN apk add --update libstdc++ && apk add wget  --virtual .build-deps && \
+RUN apk update && \
+	apk add --update libstdc++ && apk add wget  --virtual .build-deps && \
 	wget -O /opt/JDownloader/JDownloader.jar "http://installer.jdownloader.org/JDownloader.jar?$RANDOM" && chmod +x /opt/JDownloader/JDownloader.jar && \
 	wget -O /sbin/tini "https://github.com/krallin/tini/releases/download/v0.16.1/tini-static-armhf" --no-check-certificate && chmod +x /sbin/tini && \
-	apk del wget --purge .build-deps
+	apk del wget --purge .build-deps && \
+	apk add ffmpeg
 ENV LD_LIBRARY_PATH=/lib;/lib32;/usr/lib
 
 


### PR DESCRIPTION
Add ffmpeg package from the package manager, this way you can use the native one inside JDownloader. If you just install the package it could show an error about an outdated version, so it's better to run a full update of the packages.